### PR TITLE
fix: change node dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures PM2'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.7.4'
 
-depends 'nodejs', '~> 2.2.0'
+depends 'nodejs', '>= 2.2.0'
 
 supports 'centos', '~> 6.0'
 supports 'redhat', '~> 6.0'


### PR DESCRIPTION
change pesimistic operator for >=

I'm doing this because I'm experiencing a
dependency issue trying to use nodejs cookbook
2.4.4